### PR TITLE
Fix asynchronous prompt sequencing

### DIFF
--- a/chatgpt-frontend/src/App.js
+++ b/chatgpt-frontend/src/App.js
@@ -11,19 +11,19 @@ function App() {
 
   const handleAddPrompt = (newPrompts) => {
     setPrompts(newPrompts);
-    // Start the conversation with the first prompt
-    getChatGPTResponse(newPrompts[0]);
+    // Start the conversation with the first prompt and pass the full list
+    getChatGPTResponse(newPrompts[0], newPrompts);
   };
 
 
-  const getChatGPTResponse = async (prompt) => {
+  const getChatGPTResponse = async (prompt, promptList = prompts) => {
     try {
       const response = await axios.post('http://127.0.0.1:5000/chat', { prompt });
       setConversation((prev) => [...prev, response.data.response]);
       // Continue the conversation with the next prompt
-      const nextIndex = prompts.indexOf(prompt) + 1;
-      if (nextIndex < prompts.length) {
-        getChatGPTResponse(prompts[nextIndex]);
+      const nextIndex = promptList.indexOf(prompt) + 1;
+      if (nextIndex < promptList.length) {
+        getChatGPTResponse(promptList[nextIndex], promptList);
       }
     } catch (error) {
       console.error("Error fetching response:", error);


### PR DESCRIPTION
## Summary
- pass prompt array when starting conversation so `getChatGPTResponse` uses a consistent list
- recursively progress through prompts using provided list rather than stale state

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684023fc5360832f9a3d59c213482361